### PR TITLE
Replace deprecated function

### DIFF
--- a/Services/SmartFile/Client.php
+++ b/Services/SmartFile/Client.php
@@ -219,7 +219,7 @@ class Service_SmartFile_Client
         // Get Status from headers:
         $sep = strpos($response, "\r\n");
         $headers = substr($response, 0, $sep);
-        list($ignored, $http_status, $ignored) = split(' ', $headers);
+        list($ignored, $http_status, $ignored) = explode(' ', $headers);
 
         $response = $this->getBody($response);
 


### PR DESCRIPTION
`split()` has been deprecated since PHP 5.3 (and removed in PHP 7), use `explode()` instead
